### PR TITLE
fix bug when using with unite

### DIFF
--- a/plugin/auto-pairs.vim
+++ b/plugin/auto-pairs.vim
@@ -114,20 +114,20 @@ let s:InsCntUndoResetCmd = "\<C-R>=AutoPairsInsCntUndoReset()\<CR>"
 
 function! <SID>AutoPairsInsCntReset()
   if g:AutoPairsUseInsertedCount
-    let b:autopairs_ins_cnt__before_reset = b:autopairs_ins_cnt
+    let b:autopairs_ins_cnt__before_reset = <SID>AutoPairsInsCnt()
     let b:autopairs_ins_cnt = 0
   endif
 endfunction
 
 function! <SID>AutoPairsInsCntInc(cnt)
   if g:AutoPairsUseInsertedCount
-    let b:autopairs_ins_cnt = b:autopairs_ins_cnt + a:cnt
+    let b:autopairs_ins_cnt = <SID>AutoPairsInsCnt() + a:cnt
   endif
 endfunction
 
 function! <SID>AutoPairsInsCntDec()
   if g:AutoPairsUseInsertedCount
-    let b:autopairs_ins_cnt = b:autopairs_ins_cnt - 1
+    let b:autopairs_ins_cnt = max([<SID>AutoPairsInsCnt() - 1, 0])
   endif
 endfunction
 
@@ -135,12 +135,21 @@ function! <SID>AutoPairsInsCntAvail()
   let ret = 1
 
   if g:AutoPairsUseInsertedCount
-    let ret = (b:autopairs_ins_cnt > 0)
+    let ret = (<SID>AutoPairsInsCnt() > 0)
   endif
 
   return ret
 endfunction
 
+function! <SID>AutoPairsInsCnt()
+    let ret = 0
+
+    if exists('b:autopairs_ins_cnt')
+        ret = b:autopairs_ins_cnt
+    endif
+
+    return ret
+endfunction
 
 function! AutoPairsInsCntUndoReset()
   if g:AutoPairsUseInsertedCount


### PR DESCRIPTION
When using the `g:AutoPairsUseInsertedCount` option with unite, auto-pairs crashes with the error:

```
Error detected while processing function <SNR>53_AutoPairsInsCntReset:
line    2:
E121: Undefined variable: b:autopairs_ins_cnt
```

This is when you leave insert mode from a unite buffer. I think this is because the unite buffer starts in insert mode, so the count doesn't get set.

This pull request checks if the count is set, defaulting to zero.

Is this the right place to put this pull request, or should it go in @dimonomid's repo https://github.com/dimonomid/auto-pairs-gentle ?